### PR TITLE
ci(monorepo): remove [skip-ci] check in release commit name

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -34,7 +34,7 @@ module.exports = {
                 "src/**/composer.json",
                 "monorepo-builder.php"
             ],
-            "message": "chore(monorepo): release v${nextRelease.version} [skip ci]"
+            "message": "chore(monorepo): release v${nextRelease.version}"
         }]
     ]
 }


### PR DESCRIPTION
Including skip-ci in the commit message will prevent
the monorepo-split workflow from running.

Fix: #124