### PR TITLE
ci(monorepo): fix codecov.yml path settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,14 +9,14 @@ coverage:
         target: auto
         threshold: 0.01%
         paths:
-          - "src/Snicco/*"
+          - "src/Snicco"
 
     patch:
       default:
         target: auto
         threshold: 0.05%
         paths:
-          - "src/Snicco/*"
+          - "src/Snicco"
 
   precision: 3
   round: nearest


### PR DESCRIPTION
This fixes the "No coverage found on head"
message in all coverage checks.