### PR TITLE
fix(better-wpdb): fix error handling reset with unbuffered queries

### DIFF
--- a/src/Snicco/Component/better-wpdb/README.md
+++ b/src/Snicco/Component/better-wpdb/README.md
@@ -376,6 +376,10 @@ If you need full control of your sql query or have a complex use case you can di
 method. This method will return an instance of [`mysqli_stmt`](https://www.php.net/manual/de/class.mysqli-stmt.php). For
 most use cases there are more high level methods available.
 
+**!Important:** If you are using the `preparedQuery` **AND** your query is a `SELECT` query, you need to manually restore the default error handling.
+
+All other methods take care of this automatically.
+
 ```php
 
 use Snicco\Component\BetterWPDB\BetterWPDB;
@@ -384,11 +388,20 @@ $mysqli = /* ... */
 
 $better_wpdb = new BetterWPDB($mysqli);
 
+// Only for select queries.
+$auto_restore_error_handling = false;
+
 // stmt is an instance of mysqli_stmt
-$stmt = $better_wpdb->preparedQuery('select * from test_table where test_string = ? or test_int = ?', ['foo', 1]);
+$stmt = $better_wpdb->preparedQuery(
+    'select * from test_table where test_string = ? or test_int = ?', 
+    ['foo', 1],
+    $auto_restore_error_handling
+);
 
 var_dump($stmt->num_rows);
 var_dump($stmt->affected_rows);
+
+$better_wpdb->restoreErrorHandling();
 ```
 
 ❌ Never pass **ANY** user input into the first argument of `preparedQuery`

--- a/src/Snicco/Component/better-wpdb/codeception.dist.yml
+++ b/src/Snicco/Component/better-wpdb/codeception.dist.yml
@@ -8,6 +8,9 @@ paths:
 params:
   - env
 
+reporters:
+  report: "PhpStorm_Codeception_ReportPrinter"
+
 settings:
   colors: true
   disallow_test_output: true

--- a/src/Snicco/Component/better-wpdb/tests/wordpress/BetterWPDB_safeQuery_Test.php
+++ b/src/Snicco/Component/better-wpdb/tests/wordpress/BetterWPDB_safeQuery_Test.php
@@ -29,7 +29,7 @@ final class BetterWPDB_safeQuery_Test extends BetterWPDBTestCase
      */
     public function prepared_queries_can_be_run_without_placeholders(): void
     {
-        $this->better_wpdb->preparedQuery('insert into test_table (test_string) values (?)', ['foo']);
+        $this->better_wpdb->preparedQuery('insert into test_table (test_string) values (?)', ['foo'], false);
 
         $stmt = $this->better_wpdb->preparedQuery('select count(*) as record_count from test_table');
         $res = $stmt->get_result();
@@ -46,7 +46,8 @@ final class BetterWPDB_safeQuery_Test extends BetterWPDBTestCase
     {
         $stmt = $this->better_wpdb->preparedQuery(
             'insert into test_table (test_string, test_int) values (?,?)',
-            ['foo', null]
+            ['foo', null],
+            false
         );
         $this->assertSame(1, $stmt->affected_rows);
 
@@ -70,7 +71,7 @@ final class BetterWPDB_safeQuery_Test extends BetterWPDBTestCase
         $logger = new TestLogger();
         $db = BetterWPDB::fromWpdb($logger);
 
-        $db->preparedQuery('select * from test_table where test_string = ?', ['foo']);
+        $db->preparedQuery('select * from test_table where test_string = ?', ['foo'], false);
 
         $this->assertTrue(isset($logger->queries[0]));
         $this->assertCount(1, $logger->queries);


### PR DESCRIPTION
By default, mysqli prepared statements are using unbuffered
queries. This means that we can not reset the error
handling before the statement result is released
by either calling $stmt->store_result() or $stmt->getResult().

This seemed to never have worked in the first place for select queries.
Inserts, deletes etc. are not effected because they don't
return a result set.

See: https://www.php.net/manual/de/mysqlinfo.concepts.buffering.php
See: https://stackoverflow.com/a/614741