### PR TITLE
fix(testing-bundle): fix request generation of test browser

### DIFF
--- a/src/Snicco/Bundle/testing/codeception.dist.yml
+++ b/src/Snicco/Bundle/testing/codeception.dist.yml
@@ -15,6 +15,9 @@ settings:
   log_incomplete_skipped: true
   report_useless_tests: true
 
+reporters:
+  report: "PhpStorm_Codeception_ReportPrinter"
+
 coverage:
   enabled: true
   include:

--- a/src/Snicco/Bundle/testing/composer.json
+++ b/src/Snicco/Bundle/testing/composer.json
@@ -23,6 +23,7 @@
         "snicco/better-wp-mail-testing": "^1.2",
         "snicco/http-routing-testing": "^1.2",
         "snicco/http-routing-bundle": "^1.2",
+        "snicco/str-arr": "^1.2",
         "snicco/pimple-bridge": "^1.2",
         "symfony/browser-kit": "^5.4",
         "symfony/dom-crawler": "^5.4.6",
@@ -31,7 +32,6 @@
     },
     "require-dev": {
         "snicco/better-wpdb-bundle": "^1.2",
-        "snicco/str-arr": "^1.2",
         "nyholm/psr7": "^1.0.0"
     },
     "autoload": {

--- a/src/Snicco/Bundle/testing/tests/wordpress/fixtures/WebTestCaseController.php
+++ b/src/Snicco/Bundle/testing/tests/wordpress/fixtures/WebTestCaseController.php
@@ -42,6 +42,12 @@ final class WebTestCaseController extends Controller
             ->json($request->getCookieParams());
     }
 
+    public function headersAsJson(Request $request): Response
+    {
+        return $this->respondWith()
+            ->json($request->getHeaders());
+    }
+
     public function bodyAsJson(Request $request): Response
     {
         return $this->respondWith()
@@ -64,6 +70,12 @@ final class WebTestCaseController extends Controller
 
         return $this->respondWith()
             ->json($info);
+    }
+
+    public function rawBody(Request $request): Response
+    {
+        return $this->respondWith()
+            ->html((string) $request->getBody());
     }
 
     public function admin(): Response

--- a/src/Snicco/Bundle/testing/tests/wordpress/fixtures/routes/frontend.php
+++ b/src/Snicco/Bundle/testing/tests/wordpress/fixtures/routes/frontend.php
@@ -11,6 +11,7 @@ return function (WebRoutingConfigurator $router): void {
     $router->get('foo', '/foo', WebTestCaseController::class);
     $router->get('query-params-as-json', '/query-params-as-json', [WebTestCaseController::class, 'queryParams']);
     $router->get('cookies-as-json', '/cookies-as-json', [WebTestCaseController::class, 'cookiesAsJson']);
+    $router->get('headers-as-json', '/headers-as-json', [WebTestCaseController::class, 'headersAsJson']);
     $router->get('check-api-frontend', '/check-api', [WebTestCaseController::class, 'checkIfApi']);
     $router->get('full', '/full-url', [WebTestCaseController::class, 'fullUrl']);
     $router->get('custom-server', '/custom-server-vars', [WebTestCaseController::class, 'serverVars']);
@@ -23,7 +24,13 @@ return function (WebRoutingConfigurator $router): void {
     $router->post('files-as-json', '/files-as-json', [WebTestCaseController::class, 'filesAsJson']);
     $router->post('send-mail', '/send-mail', [WebTestCaseController::class, 'sendMail']);
 
-    $router->get('force-exception-middleware', '/force-exception-middleware', WebTestCaseController::class)->middleware(
+    $router->post('raw-body', '/raw-body', [WebTestCaseController::class, 'rawBody']);
+
+    $router->get(
+        'force-exception-middleware',
+        '/force-exception-middleware',
+        WebTestCaseController::class
+    )->middleware(
         MiddlewareThatAlwaysThrowsException::class
     );
 };


### PR DESCRIPTION
The Browser class had some missing pieces in the
code that transforms the Symfony Browserkit response
into a PSR7 response.

In particular, HTTP_XXX and CONTENT_XXX server params
were not transformed to headers in the PSR7 request.

Furthermore, request were marked as API requests
if the API prefix in the configuration was "/".

Fix: #140
Fix: #141