### PR TITLE
docs(better-wp-hooks): improve event listeners section in readme

### DIFF
--- a/src/Snicco/Component/better-wp-hooks/README.md
+++ b/src/Snicco/Component/better-wp-hooks/README.md
@@ -102,13 +102,13 @@ use Snicco\Component\BetterWPHooks\WPEventDispatcher;
 
 $dispatcher = WPEventDispatcher::fromDefaults();
 
-// Assumes MyListener has an __invoke method
+// Assumes OrderListener has an __invoke method
 $dispatcher->listen(OrderCreated::class, OrderListener::class);
 
-// string names work for events
+// String names work for events
 $dispatcher->listen('order_created', OrderListener::class);
 
-// Any public method works
+// Any public static method works
 $dispatcher->listen(OrderCreated::class, [OrderListener::class, 'someMethod']);
 
 // A simple closure listener

--- a/src/Snicco/Component/better-wp-hooks/README.md
+++ b/src/Snicco/Component/better-wp-hooks/README.md
@@ -108,7 +108,7 @@ $dispatcher->listen(OrderCreated::class, OrderListener::class);
 // String names work for events
 $dispatcher->listen('order_created', OrderListener::class);
 
-// Any public static method works
+// Any public method works
 $dispatcher->listen(OrderCreated::class, [OrderListener::class, 'someMethod']);
 
 // A simple closure listener


### PR DESCRIPTION
Improve "Event listeners" section in README.