### PR TITLE
fix(http-routing-bundle): enforce request data is not slashed

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -14,6 +14,8 @@
     "wp_mail",
     "add_action",
     "add_filter",
+    "did_action",
+    "doing_action",
     "apply_filters",
     "apply_filters_ref_array",
     "do_action",


### PR DESCRIPTION
WordPress will still completely nuke the request variables by slashing them with wp_magic_quotes().

There is an open ticket for this since 10+ years, but we suppose it will never get fixed.

With the http-routing-bundle we are always getting the real server variables, but this change ensures and enforces this.

See: https://core.trac.wordpress.org/ticket/18322