### PR TITLE
fix(better-wp-cli-testing,better-wpdb): #192

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -40,10 +40,11 @@ jobs:
           path: phpunit-coverage.xml
 
       - name: 'Upload coverage to codecov.io'
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }} -f phpunit-coverage.xml -Z
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: phpunit-coverage.xml
+          fail_ci_if_error: true
 
 
   codeception_coverage:
@@ -109,7 +110,8 @@ jobs:
           path: _output/codeception-coverage.xml
 
       - name: 'Upload coverage to codecov.io'
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }} -f codeception-coverage.xml -Z
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codeception-coverage.xml
+          fail_ci_if_error: true

--- a/bin/down.sh
+++ b/bin/down.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME="mysql-snicco"
+IMAGE=${1:-"mysql:8.0.28"}
+#(mariadb:latest-snicco), only [a-zA-Z0-9][a-zA-Z0-9_.-]
+CONTAINER_NAME=$(echo "$IMAGE-snicco" | tr ":" "-")
 
 # Check if the container exists
-if [ "$(docker ps -aq -f name=$CONTAINER_NAME)" ]; then
+if [ "$(docker ps -aq -f name="$CONTAINER_NAME")" ]; then
   # Stop the container
-  docker stop $CONTAINER_NAME
-  docker rm $CONTAINER_NAME
+  docker stop "$CONTAINER_NAME"
+  docker rm "$CONTAINER_NAME"
 fi

--- a/bin/up.sh
+++ b/bin/up.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME="mysql-snicco"
-MYSQL_PORT=${1:-3306}
+IMAGE=${1:-"mysql:8.0.28"}
+#(mariadb:latest-snicco), only [a-zA-Z0-9][a-zA-Z0-9_.-]
+CONTAINER_NAME=$(echo "$IMAGE-snicco" | tr ":" "-")
+MYSQL_PORT=${2:-3306}
 
 # Check if the container exists
-if [ "$(docker ps -aq -f name=$CONTAINER_NAME)" ]; then
+if [ "$(docker ps -aq -f name="$CONTAINER_NAME")" ]; then
   # Stop the container
-  docker stop $CONTAINER_NAME
-  docker rm $CONTAINER_NAME
+  docker stop "$CONTAINER_NAME"
+  docker rm "$CONTAINER_NAME"
 fi
 
-docker run -p "$MYSQL_PORT":3306 --name "$CONTAINER_NAME" -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=snicco_1 -d mysql:8.0.28
+docker run -p "$MYSQL_PORT":3306 --name "$CONTAINER_NAME" -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=snicco_1 -d "$IMAGE"

--- a/src/Snicco/Component/better-wp-cli/src/Input/Input.php
+++ b/src/Snicco/Component/better-wp-cli/src/Input/Input.php
@@ -92,11 +92,9 @@ interface Input
     public function isInteractive(): bool;
 
     /**
-     * @internal
+     * Returns the input stream - presumably STDIN.
      *
      * @return resource
-     *
-     * @psalm-internal Snicco\Component\BetterWPCLI
      */
     public function getStream();
 }

--- a/src/Snicco/Component/better-wpdb/src/KeysetPagination/Lock.php
+++ b/src/Snicco/Component/better-wpdb/src/KeysetPagination/Lock.php
@@ -10,7 +10,11 @@ namespace Snicco\Component\BetterWPDB\KeysetPagination;
 final class Lock
 {
     /**
-     * @var "for share"|"for update"
+     * @var "lock in share mode"|"for update"
+     *
+     * @interal
+     *
+     * @psalm-internal Snicco\Component\BetterWPDB
      */
     public string $type;
 
@@ -24,7 +28,8 @@ final class Lock
 
     public static function forRead(): self
     {
-        return new self('for share');
+        // "for share" is not compatible with MariaDB while for "lock in share mode" is compatible with both.
+        return new self('lock in share mode');
     }
 
     public static function forReadWrite(): self

--- a/src/Snicco/Testing/better-wp-cli/tests/fixtures/STDINTestCommand.php
+++ b/src/Snicco/Testing/better-wp-cli/tests/fixtures/STDINTestCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Snicco\Component\BetterWPCLI\Tests\Testing\fixtures;
+
+use Snicco\Component\BetterWPCLI\Command;
+use Snicco\Component\BetterWPCLI\Input\Input;
+use Snicco\Component\BetterWPCLI\Output\Output;
+
+final class STDINTestCommand extends Command
+{
+    public function execute(Input $input, Output $output): int
+    {
+        $read = [$input->getStream()];
+        $write = [];
+        $except = [];
+        $timeout = 0;
+
+        $has_data = @stream_select($read, $write, $except, $timeout);
+
+        $output->writeln($has_data ? 'PIPE' : 'NOT_A_PIPE');
+        $output->writeln((string) stream_get_contents($input->getStream()));
+
+        return 0;
+    }
+}

--- a/src/Snicco/Testing/better-wp-cli/tests/unit/CommandTesterTest.php
+++ b/src/Snicco/Testing/better-wp-cli/tests/unit/CommandTesterTest.php
@@ -14,6 +14,7 @@ use Snicco\Component\BetterWPCLI\Tests\Testing\fixtures\ColorsCommand;
 use Snicco\Component\BetterWPCLI\Tests\Testing\fixtures\FooCommand;
 use Snicco\Component\BetterWPCLI\Tests\Testing\fixtures\PositionalCommand;
 use Snicco\Component\BetterWPCLI\Tests\Testing\fixtures\PromptCommand;
+use Snicco\Component\BetterWPCLI\Tests\Testing\fixtures\STDINTestCommand;
 use Snicco\Component\BetterWPCLI\Tests\Testing\fixtures\VerboseCommand;
 use Snicco\Component\BetterWPCLI\Verbosity;
 
@@ -395,6 +396,47 @@ final class CommandTesterTest extends TestCase
         $tester = new CommandTester(new VerboseCommand());
 
         $tester->assertCommandIsSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function that_stdin_stream_is_a_pipe_if_input_is_passed(): void
+    {
+        $tester = new CommandTester(new STDINTestCommand(), [
+            'input' => ['foo'],
+        ]);
+        $tester->run();
+        $tester->seeInStdout('PIPE');
+        $tester->seeInStdout('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function that_stdin_stream_is_a_pipe_if_input_empty_input_is_passed(): void
+    {
+        $tester = new CommandTester(new STDINTestCommand(), [
+            'input' => [''],
+        ]);
+        $tester->run();
+        $tester->seeInStdout('PIPE');
+    }
+
+    /**
+     * @test
+     */
+    public function that_stdin_stream_is_a_pipe_even_if_no_input_is_passed(): void
+    {
+        // This is not the desired behavior, but there is no way to make an in-memory stream
+        // which will not crash select_stream on PHP8+
+        // It should have been a tmp stream from the beginning, they are identical with the
+        // only meaningful difference being that tmp will work with stream_select (always returns 1).
+        $tester = new CommandTester(new STDINTestCommand(), [
+            'input' => [],
+        ]);
+        $tester->run();
+        $tester->seeInStdout('PIPE');
     }
 
     private function expectFailure(string $message, Closure $test): void


### PR DESCRIPTION
… test stdin

It should have been a tmp stream from the beginning. They are identical with the only meaningful difference being that tmp will work with stream_select (always returns 1) while memory will throw a fatal error with stream_select on PHP8+.

This is an issue because stream_select is the recommended way to check if reading from STDIN will block forever because it's interactive/the terminal.