### PR TITLE
fix(kernel): don't check if directories are readable in constructor

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -11,6 +11,7 @@ jobs:
 
   phpunit_coverage:
     name: 'PHPUnit coverage'
+    if: github.repository == 'snicco/snicco'
     runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout code'
@@ -41,7 +42,6 @@ jobs:
 
       - name: 'Upload coverage to codecov.io'
         # only upload if this is not a fork
-        if: github.repository == 'snicco/snicco'
         uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -51,6 +51,7 @@ jobs:
 
   codeception_coverage:
     name: 'Codeception coverage'
+    if: github.repository == 'snicco/snicco'
     runs-on: ubuntu-20.04
     services:
       mysql:
@@ -113,7 +114,6 @@ jobs:
 
       - name: 'Upload coverage to codecov.io'
         # only upload if this is not a fork
-        if: github.repository == 'snicco/snicco'
         uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - master
+      - beta
 
 jobs:
   release:
     name: 'Release'
+    # don't run on forks
+    if: github.repository == 'snicco/snicco'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,6 +20,12 @@ jobs:
           # Commits will then fail due to branch protection rules.
           token: ${{ secrets.ACCESS_TOKEN }}
           fetch-depth: 0
+
+      - name: Store pushed branch in env
+        run: |
+          PUSHED_BRANCH=${GITHUB_REF#refs/heads/}
+          echo "PUSHED_BRANCH=${PUSHED_BRANCH}" >> $GITHUB_ENV
+          echo "Pushed branch is $PUSHED_BRANCH"
 
       - name: 'Setup Node.js'
         uses: actions/setup-node@v2
@@ -53,7 +62,7 @@ jobs:
             result = github.rest.repos.deleteAdminBranchProtection({
               owner: 'snicco',
               repo: 'snicco',
-              branch: 'master'
+              branch: ${{ env.PUSHED_BRANCH }}
             })
 
       - name: 'Semantic release'
@@ -78,5 +87,5 @@ jobs:
             result = github.rest.repos.setAdminBranchProtection({
               owner: 'snicco',
               repo: 'snicco',
-              branch: 'master'
+              branch: ${{ env.PUSHED_BRANCH }}
             })

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _output
 node_modules
 package-lock.json
 wp
+.idea
 
 # temporary
 /bin/change-packages
@@ -20,3 +21,4 @@ wp
 /src/Snicco/*/*/composer.lock
 /src/Snicco/*/*/phpunit.xml
 /src/Snicco/*/*/tests/_output/*
+

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "branches": [
-        "master"
+        "master",
+        "{name: 'beta', prerelease: true}"
     ],
     "repositoryUrl": "https://github.com/snicco/snicco.git",
     "tagFormat": "v${version}",

--- a/src/Snicco/Component/kernel/src/ValueObject/Directories.php
+++ b/src/Snicco/Component/kernel/src/ValueObject/Directories.php
@@ -6,7 +6,7 @@ namespace Snicco\Component\Kernel\ValueObject;
 
 use Webmozart\Assert\Assert;
 
-use function sprintf;
+use function rtrim;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -19,30 +19,52 @@ use const DIRECTORY_SEPARATOR;
  */
 final class Directories
 {
+    /**
+     * @var non-empty-string
+     */
     private string $config_dir;
 
+    /**
+     * @var non-empty-string
+     */
     private string $cache_dir;
 
+    /**
+     * @var non-empty-string
+     */
     private string $log_dir;
 
+    /**
+     * @var non-empty-string
+     */
     private string $base_directory;
 
     public function __construct(string $base_directory, string $config_dir, string $cache_dir, string $log_dir)
     {
-        Assert::readable($base_directory, sprintf('$base_directory [%s] is not readable.', $base_directory));
+        $base_directory = rtrim($base_directory, DIRECTORY_SEPARATOR);
+        $config_dir = rtrim($config_dir, DIRECTORY_SEPARATOR);
+        $cache_dir = rtrim($cache_dir, DIRECTORY_SEPARATOR);
+        $log_dir = rtrim($log_dir, DIRECTORY_SEPARATOR);
 
-        Assert::readable($config_dir, sprintf('$config_dir [%s] is not readable.', $config_dir));
+        Assert::stringNotEmpty($base_directory, 'The base directory must be a non-empty string.');
+        Assert::startsWith(
+            $base_directory,
+            DIRECTORY_SEPARATOR,
+            'The base directory must be an absolute path. Got: %s'
+        );
+        $this->base_directory = $base_directory;
 
-        Assert::readable($cache_dir, sprintf('$cache_dir [%s] is not readable.', $cache_dir));
-        Assert::writable($cache_dir, sprintf('$cache_dir [%s] is not writable.', $cache_dir));
+        Assert::stringNotEmpty($config_dir, 'The config directory must be a non-empty string.');
+        Assert::startsWith($config_dir, DIRECTORY_SEPARATOR, 'The config directory must be an absolute path. Got: %s');
+        $this->config_dir = $config_dir;
 
-        Assert::readable($log_dir, sprintf('$log_dir [%s] is not readable.', $log_dir));
-        Assert::writable($log_dir, sprintf('$log_dir [%s] is not writable.', $log_dir));
+        Assert::stringNotEmpty($cache_dir, 'The cache directory must be a non-empty string.');
+        Assert::startsWith($cache_dir, DIRECTORY_SEPARATOR, 'The cache directory must be an absolute path. Got: %s');
+        $this->cache_dir = $cache_dir;
 
-        $this->config_dir = rtrim($config_dir, DIRECTORY_SEPARATOR);
-        $this->cache_dir = rtrim($cache_dir, DIRECTORY_SEPARATOR);
-        $this->log_dir = rtrim($log_dir, DIRECTORY_SEPARATOR);
-        $this->base_directory = rtrim($base_directory, DIRECTORY_SEPARATOR);
+        Assert::stringNotEmpty($log_dir, 'The log directory must be a non-empty string.');
+        Assert::startsWith($log_dir, DIRECTORY_SEPARATOR, 'The log directory must be an absolute path. Got: %s');
+        $this->log_dir = $log_dir;
     }
 
     public static function fromDefaults(string $base_directory): Directories
@@ -66,21 +88,33 @@ final class Directories
         return new self($base_directory, $config_dir, $cache_dir, $log_dir);
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function configDir(): string
     {
         return $this->config_dir;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function baseDir(): string
     {
         return $this->base_directory;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function cacheDir(): string
     {
         return $this->cache_dir;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function logDir(): string
     {
         return $this->log_dir;

--- a/src/Snicco/Component/kernel/tests/ValueObject/DirectoriesTest.php
+++ b/src/Snicco/Component/kernel/tests/ValueObject/DirectoriesTest.php
@@ -38,17 +38,6 @@ final class DirectoriesTest extends TestCase
     /**
      * @test
      */
-    public function test_exception_if_base_directory_is_not_readable(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$base_directory [bogus] is not readable.');
-
-        Directories::fromDefaults('bogus');
-    }
-
-    /**
-     * @test
-     */
     public function test_config_directory(): void
     {
         $dirs = Directories::fromDefaults($this->valid_base_dir);
@@ -79,43 +68,44 @@ final class DirectoriesTest extends TestCase
     /**
      * @test
      */
-    public function test_exception_if_config_dir_not_readable(): void
+    public function exception_if_base_dir_not_absolute(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('$config_dir [%s] is not readable', __DIR__ . '/config'));
+        $this->expectExceptionMessage('The base directory must be an absolute path. Got: "relative/path"');
 
-        new Directories(__DIR__, __DIR__ . '/config', __DIR__ . '/cache', __DIR__ . '/log');
+        Directories::fromDefaults('relative/path');
     }
 
     /**
      * @test
      */
-    public function test_exception_if_cache_dir_not_readable(): void
+    public function exception_if_config_dir_relative(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('$cache_dir [%s] is not readable', __DIR__ . '/cache'));
+        $this->expectExceptionMessage('The config directory must be an absolute path. Got: "relative/path"');
 
-        new Directories(
-            $this->valid_base_dir,
-            $this->valid_base_dir . '/config',
-            __DIR__ . '/cache',
-            __DIR__ . '/log'
-        );
+        new Directories('/base', 'relative/path', '/cache', '/log');
     }
 
     /**
      * @test
      */
-    public function test_exception_if_log_dir_not_readable(): void
+    public function exception_if_cache_dir_relative(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('$log_dir [%s] is not readable', __DIR__ . '/log'));
+        $this->expectExceptionMessage('The cache directory must be an absolute path. Got: "relative/path"');
 
-        new Directories(
-            $this->valid_base_dir,
-            $this->valid_base_dir . '/config',
-            $this->valid_base_dir . '/var/cache',
-            __DIR__ . '/log'
-        );
+        new Directories('/base', '/config', 'relative/path', '/log');
+    }
+
+    /**
+     * @test
+     */
+    public function exception_if_log_dir_relative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The log directory must be an absolute path. Got: "relative/path"');
+
+        new Directories('/base', '/config', '/cache', 'relative/path');
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: Previously creating an instance of the kernel class always asserted that cache/log/config dirs are
readable.
This created a lot of development complexities as these directories always had to be pre-created before a kernel instance could be created. It also creates runtime overhead for little additional safety. There is no way to ensure that a directory did not go missing between Directories::__construct(), and the usage of any directory. Callers of the Directory class are now responsible for error handling, as they should always have.