### PR TITLE
feat(*): stricter directory permissions for all cache files

### DIFF
--- a/src/Snicco/Bundle/http-routing/src/MiddlewareCache.php
+++ b/src/Snicco/Bundle/http-routing/src/MiddlewareCache.php
@@ -55,10 +55,10 @@ final class MiddlewareCache
         $parent_dir = dirname($cache_file);
         if (! is_dir($parent_dir)) {
             // suppress warnings in case multiple requests are trying to create the same directory.
-            @mkdir($parent_dir, 0755, true);
+            @mkdir($parent_dir, 0700, true);
         }
 
-        FileWriter::writeFile($cache_file, '<?php return ' . var_export($data, true) . ';', 0644);
+        FileWriter::writeFile($cache_file, '<?php return ' . var_export($data, true) . ';', 0600);
 
         return MiddlewareResolver::fromCache($data['route_map'], $data['request_map']);
     }

--- a/src/Snicco/Component/http-routing/src/Routing/Cache/FileRouteCache.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Cache/FileRouteCache.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Snicco\Component\HttpRouting\Routing\Cache;
 
 use Closure;
-use Webimpress\SafeWriter\Exception\ExceptionInterface;
 use Webimpress\SafeWriter\FileWriter;
 
 use function dirname;
@@ -18,14 +17,11 @@ final class FileRouteCache implements RouteCache
 
     private string $path;
 
-    private int $file_permission;
-
-    public function __construct(string $cache_path, int $file_permission = 0644)
+    public function __construct(string $cache_path)
     {
         $this->path = $cache_path;
         $this->empty_error_handler = function (): void {
         };
-        $this->file_permission = $file_permission;
     }
 
     public function get(callable $loader): array
@@ -41,10 +37,10 @@ final class FileRouteCache implements RouteCache
         $parent_dir = dirname($this->path);
         if (! is_dir($parent_dir)) {
             // suppress warnings in case multiple requests are trying to create the same directory.
-            @mkdir($parent_dir, 0755, true);
+            @mkdir($parent_dir, 0700, true);
         }
 
-        $this->writeToFile($this->path, '<?php return ' . var_export($data, true) . ';');
+        FileWriter::writeFile($this->path, '<?php return ' . var_export($data, true) . ';', 0600);
 
         return $data;
     }
@@ -66,13 +62,5 @@ final class FileRouteCache implements RouteCache
 
         /** @var array{url_matcher: array, route_collection: array<string,string>, admin_menu: array<string>} $value */
         return $value;
-    }
-
-    /**
-     * @throws ExceptionInterface
-     */
-    private function writeToFile(string $path, string $content): void
-    {
-        FileWriter::writeFile($path, $content, $this->file_permission);
     }
 }

--- a/src/Snicco/Component/kernel/src/Configuration/PHPFileCache.php
+++ b/src/Snicco/Component/kernel/src/Configuration/PHPFileCache.php
@@ -37,10 +37,10 @@ final class PHPFileCache implements ConfigCache
         $cache_file_parent_dir = dirname($key);
         if (! is_dir($cache_file_parent_dir)) {
             // suppress warnings in case multiple requests are trying to create the same directory.
-            @mkdir($cache_file_parent_dir, 0755, true);
+            @mkdir($cache_file_parent_dir, 0700, true);
         }
 
-        FileWriter::writeFile($key, '<?php return ' . var_export($config, true) . ';', 0644);
+        FileWriter::writeFile($key, '<?php return ' . var_export($config, true) . ';', 0600);
 
         return $config;
     }


### PR DESCRIPTION
BREAKING CHANGE:
all cache directories are created with 0700
permissions and all files with 0600.
Previously, they were created with 0755/0644.